### PR TITLE
Add defensive programming to object check

### DIFF
--- a/lib/mixins/link.js
+++ b/lib/mixins/link.js
@@ -21,6 +21,10 @@ module.exports = link;
 function link(definition) {
   var key, link, newResource, Resource;
 
+  if (typeof definition !== 'object') {
+    return;
+  };
+
   if ('_links' in definition) {
     for (key in definition._links) {
       if (key === 'self') continue;


### PR DESCRIPTION
Basically, one if to guarantee that description is an object to can user "in".